### PR TITLE
Remove pre-commit-hooks-safety

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -105,8 +105,3 @@ repos:
         language: system
         entry: ./bin/o2a-validate-all-workflows
         files: \workflow.xml$
-  - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    sha: "v1.1.0"
-    hooks:
-      - id: python-safety-dependencies-check
-        name: Checks for security vulnerabilities in dependencies


### PR DESCRIPTION
Make sure you have checked _all_ steps below and that above description is correct.

### JIRA
No JIRA

This hook causes more problems than benefits:
* it does not work without internet, so:
  * It is slow 
  * Blocks programming without internet
* it is redundant. We have  protection from Github: https://help.github.com/en/articles/configuring-automated-security-fixes
* it's not secure. All results is public available in CI.

### Tests
- [ ] My PR has unit tests testing the functionality (or I explained why it needs no tests)

### Commits
- [ ] My commits reference the issue in the message using: Fixes #XXX /Closes #XXX or similar.

### Documentation
- [ ] My PR adds documentation that describes how to use it (or I explained why it needs no docs)
