### PR TITLE
Fix converting relation after spliting ParsedActionNode

### DIFF
--- a/o2a/converter/oozie_converter.py
+++ b/o2a/converter/oozie_converter.py
@@ -117,7 +117,12 @@ class OozieConverter:
             p_node.tasks = tasks
             p_node.relations = relations
             self.workflow.task_groups[name] = TaskGroup(
-                name=name, tasks=tasks, relations=relations, dependencies=dependencies
+                name=name,
+                tasks=tasks,
+                relations=relations,
+                dependencies=dependencies,
+                downstream_names=p_node.downstream_names,
+                error_downstream_name=p_node.error_downstream_name,
             )
             del self.workflow.nodes[name]
 

--- a/o2a/converter/task_group.py
+++ b/o2a/converter/task_group.py
@@ -120,7 +120,7 @@ class TaskGroup:
 
     def __repr__(self) -> str:
         return (
-            f"ParsedActionNode(name={self.name}, "
+            f"TaskGroup(name={self.name}, "
             f"downstream_names={self.downstream_names}, "
             f"error_downstream_name={self.error_downstream_name}, "
             f"tasks={self.tasks}, relations={self.relations})"

--- a/tests/converter/test_oozie_converter.py
+++ b/tests/converter/test_oozie_converter.py
@@ -246,7 +246,7 @@ class TestOozieConverter(TestCase):
 
 
 class TestOozieConvertByExamples(TestCase):
-    def test_should_convert_dem_workflow(self):
+    def test_should_convert_demo_workflow(self):
         renderer = mock.MagicMock()
 
         transformers = [


### PR DESCRIPTION
During the last refactoring there were problems that the relations were not correctly converted. This patch corrects the error and adds an integration test that prevents future regression.

### JIRA
No Jira

### Tests
- [X] My PR has unit tests testing the functionality (or I explained why it needs no tests)

### Commits
N/A

### Documentation
N/A