### PR TITLE
Allows o2a to be installed with PIP install after Werkzeug drama

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ output
 /dist/
 *.egg-info/
 /.eggs/
+/pip-wheel-metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ flake8==3.7.7
 google-api-python-client==1.7.9
 isort==4.3.21
 j2cli==0.3.10
-Jinja2==2.10.1
+Jinja2==2.10.0 # pyup: ignore
 lark-parser==0.7.1
 mypy==0.711
 parameterized==0.7.0
@@ -17,4 +17,6 @@ pytest-cov==2.7.1
 safety==1.8.5
 sshtunnel==0.1.5
 twine==1.13.0
+tzlocal==1.5.1 # pyup: ignore
+Werkzeug==0.14.1 # pyup: ignore
 yamllint==1.16.0


### PR DESCRIPTION
Fixes #308

More context: https://github.com/apache/airflow/pull/5535

Make sure you have checked _all_ steps below and that above description is correct.

### JIRA
- [x] My PR addresses the following [Issue](https://github.com/GoogleCloudPlatform/oozie-to-airflow/issues/308)
issue and references it in commit message.

### Tests
- [x] My PR has unit tests testing the functionality (or I explained why it needs no tests)
No need to test automatically. You can test manually by `pip install -e .` before and after.

### Commits
- [x] My commits reference the issue in the message using: Fixes #XXX /Closes #XXX or similar.

### Documentation
- [x] My PR adds documentation that describes how to use it (or I explained why it needs no docs)
No need.