### PR TITLE
chore(deps): update apache-airflow to patched 1.10.15 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow==2.4.2 # pyup: ignore
+apache-airflow==1.10.15 # pyup: ignore
 autoflake==1.4
 black==20.8b1
 flake8==3.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow==1.10.14 # pyup: ignore
+apache-airflow==2.4.2 # pyup: ignore
 autoflake==1.4
 black==20.8b1
 flake8==3.8.4


### PR DESCRIPTION
Addresses https://github.com/GoogleCloudPlatform/oozie-to-airflow/security/dependabot/2 — this tool isn't compatible with Airflow 2 so we won't be able to upgrade past this. 
